### PR TITLE
Version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10-dind
+FROM docker:20.10.17-dind
 
 RUN apk add --no-cache \
 		git \
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 		python3 \
         py3-pip
 
-ENV SKAFFOLD_VERSION 1.37.2
+ENV SKAFFOLD_VERSION 1.39.2
 RUN curl -f -Lo skaffold https://github.com/GoogleCloudPlatform/skaffold/releases/download/v${SKAFFOLD_VERSION}/skaffold-linux-amd64 && \
   chmod +x skaffold && \
   mv skaffold /usr/bin && \
@@ -23,12 +23,12 @@ RUN curl -f -Lo container-structure-test https://storage.googleapis.com/containe
   chmod +x container-structure-test && \
   mv container-structure-test /usr/bin
 
-ENV KUBECTL_VERSION 1.24.0
+ENV KUBECTL_VERSION 1.25.0
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
   chmod +x ./kubectl && \
   mv ./kubectl /usr/local/bin/kubectl
 
-ENV HELM_VERSION 3.9.0
+ENV HELM_VERSION 3.9.4
 RUN curl -f -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -zx && \
   chmod +x linux-amd64/helm && \
   mv linux-amd64/helm /usr/bin && \

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ stage('Build') {
 > **_NOTE:_** For more information on using Skaffold in a Jenkins pipeline, read the [Liatrio's Blog Post](https://www.liatrio.com/blog/delivery-pipelines-with-skaffold) on the topic.
 
 ## What is installed on this image?
-- Version [1.37.X](https://github.com/GoogleCloudPlatform/skaffold/releases/download/v1.37.2/skaffold-linux-amd64) of Skaffold, a command line tool that facilitates continuous development for Kubernetes applications
+- Version [1.39.X](https://github.com/GoogleCloudPlatform/skaffold/releases/download/v1.39.2/skaffold-linux-amd64) of Skaffold, a command line tool that facilitates continuous development for Kubernetes applications
 - Version [1.24](https://github.com/aws/aws-cli) of the AWS CLI
 - Version [1.11.X](https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-amd64) of Container Structure Tests, a framework to validate the structure of a container image
-- Version [1.24.X](https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl) of kubectl, a command-line tool that allows you to run commands against Kubernetes clusters
-- Version [3.9.0](https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz) of Helm, a package manager for Kubernetes
+- Version [1.25.X](https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl) of kubectl, a command-line tool that allows you to run commands against Kubernetes clusters
+- Version [3.9.4](https://get.helm.sh/helm-v3.9.4-linux-amd64.tar.gz) of Helm, a package manager for Kubernetes


### PR DESCRIPTION
Resolves [CVE-2022-1996](https://avd.aquasec.com/nvd/2022/cve-2022-1996/) with Helm version bump. 